### PR TITLE
Style fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,7 +5,6 @@
   color: #666;
   justify-content: flex-start;
   align-items: flex-start;
-  margin-top: 80px;
 }
 
 .dg_service_counter {
@@ -37,7 +36,8 @@
   font-weight: 900;
 }
 
-.dg_search_noresults,
-.dg_search_header {
-  margin-top: 30px;
+@media screen and (max-width: 992px) {
+  .dg_search_header {
+    margin-top: 30px;
+  }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -35,9 +35,3 @@
   margin-left: 5px;
   font-weight: 900;
 }
-
-@media screen and (max-width: 992px) {
-  .dg_search_header {
-    margin-top: 30px;
-  }
-}

--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,8 @@
   margin-left: 5px;
   font-weight: 900;
 }
+
+.dg_search_noresults,
+.dg_search_header {
+  margin-top: 30px;
+}

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -110,7 +110,10 @@ const ServiceList = () => {
                 />
               </div>
             ) : (
-              "Sorry, no services match your search criteria. Please change your search term and try again"
+              <p className="dg_search_noresults">
+                Sorry, no services match your search criteria. Please change
+                your search term and try again
+              </p>
             )}
           </div>
         </div>

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -70,7 +70,7 @@ const ServiceList = () => {
               checked={isMostPopular}
             />
           </div>
-          <div className="col-md-9 col-xs-12">
+          <div className="col-md-9 col-xs-12 dg_search_header">
             <TextInput
               id="full-name"
               label="Search for services"

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -110,7 +110,7 @@ const ServiceList = () => {
                 />
               </div>
             ) : (
-              <p className="dg_search_noresults">
+              <p>
                 Sorry, no services match your search criteria. Please change
                 your search term and try again
               </p>

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -70,7 +70,7 @@ const ServiceList = () => {
               checked={isMostPopular}
             />
           </div>
-          <div className="col-md-9 col-xs-12 dg_search_header">
+          <div className="col-md-9 col-xs-12">
             <TextInput
               id="full-name"
               label="Search for services"


### PR DESCRIPTION
Added some spacing on the search box once screen shrinks to give some separation to the filters and the search. Removed the 80px top margin for the legend as this will be handled elsewhere and would have blown out the spacing. So for now its kind of cramped.

Addresses:
15858: Add Margin Between Filter and Search Area <768 pixels

**UPDATE**:
The changes made here need to be moved to the component project. This request does NOT address any bugs and instead heads off one bug with the removal of the 80px margin on the legend which will conflict with other changes being made out side of this project.