### PR TITLE
Fix Filtering issue

### DIFF
--- a/src/common/Filter.js
+++ b/src/common/Filter.js
@@ -1,0 +1,18 @@
+const FilterServices = (
+  services = [],
+  shouldShowMostPopularServices,
+  searchText
+) =>
+  [...services]
+    .filter(item => !shouldShowMostPopularServices || item.rank > 0)
+    .filter(item => !searchText.trim || filterByTextInput(item, searchText));
+
+const filterByTextInput = (item, searchText) => {
+  return (
+    item.name.toLowerCase().indexOf(searchText.trim().toLowerCase()) !== -1 ||
+    item.department.toLowerCase().indexOf(searchText.trim().toLowerCase()) !==
+      -1
+  );
+};
+
+export { FilterServices };

--- a/src/common/Filter.js
+++ b/src/common/Filter.js
@@ -7,12 +7,21 @@ const FilterServices = (
     .filter(item => !shouldShowMostPopularServices || item.rank > 0)
     .filter(item => !searchText.trim || filterByTextInput(item, searchText));
 
-const filterByTextInput = (item, searchText) => {
-  return (
-    item.name.toLowerCase().indexOf(searchText.trim().toLowerCase()) !== -1 ||
-    item.department.toLowerCase().indexOf(searchText.trim().toLowerCase()) !==
-      -1
+const generateWordMatchRegex = word => "(?=.*" + word + ")";
+
+const filterByTextInput = ({ name, department }, searchText) => {
+  const searchWordsRegex = searchText
+    .split(" ")
+    .map(field => generateWordMatchRegex(field))
+    .join("");
+  const fieldsAsString = [name, department].join(" ").toLowerCase();
+  const isTextMatch =
+    fieldsAsString.indexOf(searchText.toLowerCase().trim()) > -1;
+  const isSearchWordsMatch = fieldsAsString.match(
+    new RegExp(searchWordsRegex + "+", "gi")
   );
+
+  return isTextMatch || isSearchWordsMatch;
 };
 
 export { FilterServices };

--- a/src/common/Filter.js
+++ b/src/common/Filter.js
@@ -1,3 +1,9 @@
+/**
+ * Filters a list of services for the given filters
+ * @param {array} services list of services to filter
+ * @param {boolean} shouldShowMostPopularServices determines of whether you should show only popular services, null is possible
+ * @param {boolean} searchText search text
+ */
 const FilterServices = (
   services = [],
   shouldShowMostPopularServices,

--- a/src/common/Filter.js
+++ b/src/common/Filter.js
@@ -13,12 +13,12 @@ const FilterServices = (
     .filter(item => !shouldShowMostPopularServices || item.rank > 0)
     .filter(item => !searchText.trim || filterByTextInput(item, searchText));
 
-const generateWordMatchRegex = word => "(?=.*" + word + ")";
+const generateWordMatchRegexPattern = word => "(?=.*" + word + ")";
 
 const filterByTextInput = ({ name, department }, searchText) => {
   const searchWordsRegex = searchText
     .split(" ")
-    .map(field => generateWordMatchRegex(field))
+    .map(field => generateWordMatchRegexPattern(field))
     .join("");
   const fieldsAsString = [name, department].join(" ").toLowerCase();
   const isTextMatch =

--- a/src/common/Filter.test.js
+++ b/src/common/Filter.test.js
@@ -1,0 +1,86 @@
+import { FilterService } from "./Filter";
+
+const mockServices = [
+  {
+    name: "Adopt a Pet",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-heart",
+    rank: 5,
+    department: "Information Technology"
+  },
+  {
+    name: "Apply for a Job",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-skiing",
+    rank: 2,
+    department: "Information Technology"
+  },
+  {
+    name: "Citations",
+    url:
+      "https://beta.baltimorecountymd.gov/departments/budfin/citations/index.html",
+    icon: "fas fa-receipt",
+    rank: 3,
+    department: "Law Office"
+  },
+  {
+    name: "County Code",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-fighter-jet",
+    rank: 4,
+    department: "Information Technology"
+  },
+  {
+    name: "Find Your Zoning",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-heart",
+    rank: 5,
+    department: "Information Technology"
+  },
+  {
+    name: "Jury Duty",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-heart",
+    rank: 6,
+    department: "Law Office"
+  },
+  {
+    name: "Police News",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-starship-freighter",
+    rank: 7,
+    department: "Information Technology"
+  },
+  {
+    name: "Quality Assurance",
+    url: "https://beta.baltimorecountymd.gov/services.html",
+    icon: "fas fa-drafting-compass",
+    rank: 0,
+    department: "Information Technology"
+  },
+  {
+    name: "Rec and Parks",
+    url: "http://staging.baltimorecountymd.gov/recreation/index.html",
+    icon: "fas fa-tree",
+    rank: 8,
+    department: "Information Technology"
+  },
+  {
+    name: "Trash and Recycling",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-trash",
+    rank: 9,
+    department: "Information Technology"
+  },
+  {
+    name: "View Daily Docket",
+    url: "https://beta.baltimorecountymd.gov/prototyping/adoption.html",
+    icon: "fas fa-heart",
+    rank: 10,
+    department: "Information Technology"
+  }
+];
+
+test.todo("should retrieve full card contents", () => {
+  const actual = FilterService(mockServices, null, "citations law office");
+});

--- a/src/common/Filter.test.js
+++ b/src/common/Filter.test.js
@@ -1,4 +1,4 @@
-import { FilterService } from "./Filter";
+import { FilterServices } from "./Filter";
 
 const mockServices = [
   {
@@ -81,6 +81,17 @@ const mockServices = [
   }
 ];
 
-test.todo("should retrieve full card contents", () => {
-  const actual = FilterService(mockServices, null, "citations law office");
+test("should retrieve full card contents", () => {
+  const actual = FilterServices(mockServices, null, "j");
+  expect(actual.length).toEqual(2);
+});
+
+test("should retrieve full card contents", () => {
+  const actual = FilterServices(mockServices, null, "citations law office");
+  expect(actual.length).toEqual(1);
+});
+
+test("should retrieve full card contents with out of order text", () => {
+  const actual = FilterServices(mockServices, null, "law jury");
+  expect(actual.length).toEqual(1);
 });

--- a/src/components/ServiceList.jsx
+++ b/src/components/ServiceList.jsx
@@ -2,20 +2,13 @@ import React, { useState } from "react";
 
 import { Alert } from "@baltimorecounty/dotgov-components";
 import FilterList from "./FilterList";
+import { FilterServices } from "../common/Filter";
 import ListCounter from "./ListCounter";
 import ListLegend from "./ListLegend";
 import PopularityFilterCollapse from "./PopularityFilterCollapse";
 import ServiceIconLink from "./ServiceIconLink";
 import { TextInput } from "@baltimorecounty/dotgov-components";
 import useServices from "../hooks/useServices";
-
-const filterByTextInput = (item, searchText) => {
-  return (
-    item.name.toLowerCase().indexOf(searchText.trim().toLowerCase()) !== -1 ||
-    item.department.toLowerCase().indexOf(searchText.trim().toLowerCase()) !==
-      -1
-  );
-};
 
 const ServiceList = () => {
   const { hasError, serviceItems = [], isLoading } = useServices();
@@ -24,25 +17,18 @@ const ServiceList = () => {
   const [filterText, setFilterText] = useState([]);
   const [isFiltering, setIsFiltering] = useState(false);
 
-  const filterServiceList = (shouldShowMostPopularServices, searchText) => {
-    const items = [...serviceItems]
-      .filter(item => !shouldShowMostPopularServices || item.rank > 0)
-      .filter(item => !searchText.trim || filterByTextInput(item, searchText));
-    setFilteredItems(items);
-  };
-
   const handleIsPopularFilterChange = changeEvent => {
     const { checked } = changeEvent.target;
     setMostPopular(checked);
     setIsFiltering(filterText.length > 0 || checked);
-    filterServiceList(checked, filterText);
+    setFilteredItems(FilterServices(serviceItems, checked, filterText));
   };
 
   const handleTextInputFilterChange = changeEvent => {
     const { value } = changeEvent.target;
     setIsFiltering(value.length > 0 || isMostPopular);
     setFilterText(value);
-    filterServiceList(isMostPopular, value);
+    setFilteredItems(FilterServices(serviceItems, isMostPopular, value));
   };
 
   if (hasError) {


### PR DESCRIPTION
Improved filter to match

- Maintained text search
- Match words in card regardless of order

To expose this bug in the current system. You can test the following.

- Type "citations law office" into the text filter, this matches all of the words on a particular card, but shows a no results message
- Type "law jury" into the text filter, should return the "jury duty" card despite the filter "terms" eing in the same order as they are displayed in the card. This ultimately ends up with a no results message, but should show results.